### PR TITLE
Set RemoteImage to compile only on canImport(SwiftUI)

### DIFF
--- a/Sources/AsyncImageFetcher/AsyncImageFetcher.swift
+++ b/Sources/AsyncImageFetcher/AsyncImageFetcher.swift
@@ -9,12 +9,12 @@ import UIKit
 import Combine
 
 /// A LocalizedError related to image fetching.
-enum ImageFetchError: LocalizedError {
+public enum ImageFetchError: LocalizedError {
   case invalidData
   case invalidURL
 
   /// The error description String.
-  var errorDescription: String? {
+  public var errorDescription: String? {
     switch self {
     case .invalidData:
       return NSLocalizedString("Unable to fetch image from data", comment: "")
@@ -32,7 +32,7 @@ class AsyncImageFetcher {
 extension UIImage {
   /// Returns a publisher which fetches a UIImage from a URL.
   /// - Parameter urlString: The URL (in String format) from which to fetch the image.
-  static func load(from urlString: String) -> AnyPublisher<UIImage?, ImageFetchError> {
+  public static func load(from urlString: String) -> AnyPublisher<UIImage?, ImageFetchError> {
     guard let url = URL(string: urlString) else {
       return Fail(error: ImageFetchError.invalidURL)
         .eraseToAnyPublisher()

--- a/Sources/AsyncImageFetcher/Views/RemoteImage.swift
+++ b/Sources/AsyncImageFetcher/Views/RemoteImage.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Combine
 
+#if canImport(SwiftUI)
 /// A view containing an image and an optional placeholder, asynchronously fetched from a URL.
 public struct RemoteImage: View {
 
@@ -91,4 +92,5 @@ public struct RemoteImage_Previews: PreviewProvider {
     RemoteImage(url: "")
   }
 }
+#endif
 #endif


### PR DESCRIPTION
There's not reason to compile RemoteImage in case SwiftUI couldn't be imported.